### PR TITLE
Make derived hash functions allocation free

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
       - name: Build
         run: opam exec -- dune build
 
+      - name: Test
+        run: opam exec -- dune test
 
   lower-bounds-downgrade:
     # use external 0install solver to downgrade: https://github.com/ocaml-opam/opam-0install-solver
@@ -82,7 +84,6 @@ jobs:
 
       - name: Build
         run: opam exec -- dune build
-
 
   opam-install:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4
+* Make derived hash functions allocation-free.
+* Fix a bug where hash functions couldn't be used on the RHS of `let rec` bindings.
+
 ## 0.1.3
 * Add `lazy` support (#5).
 * Migrate to OCaml 5.2 AST for ppxlib 0.36.0 (#6).

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -1,0 +1,121 @@
+(* Benchmark for [@@deriving hash]: measures throughput and *per-call
+   allocation* of the derived hash functions, and compares against the
+   polymorphic [Stdlib.Hashtbl.hash] baseline.
+
+   The derived hash should never allocate. *)
+
+(* ---- Representative types ---- *)
+
+type expr =
+  | Lit of int
+  | Neg of expr
+  | Add of expr * expr
+  | Many of expr list
+  | Lab of string * expr
+[@@deriving hash]
+
+type rgb = { r : int; g : int; b : int } [@@deriving hash]
+type pair = int * int [@@deriving hash]
+type flat = A | B | C | D | E [@@deriving hash]
+type ints = int list [@@deriving hash]
+type matrix = int list list [@@deriving hash]
+
+(* Recursive type reached through a parametrized alias ([_ hash_consed]) -- the
+   shape used by hash-consing libraries. Exercises the eta-expanded application
+   path (which must stay allocation-free and be a valid [let rec] RHS). *)
+type 'a hash_consed = { node : 'a; tag : int }
+
+let hash_hash_consed _ x = x.tag
+
+type tree_kind = Leaf of int | Branch of tree * tree
+and tree = tree_kind hash_consed [@@deriving hash]
+
+(* ---- Value generators (deterministic) ---- *)
+
+let () = Random.init 0x1234
+
+let rec gen_expr depth =
+  if depth <= 0 then
+    match Random.int 2 with
+    | 0 -> Lit (Random.int 1_000_000)
+    | _ -> Lab (string_of_int (Random.int 1000), Lit (Random.int 100))
+  else
+    match Random.int 5 with
+    | 0 -> Lit (Random.int 1_000_000)
+    | 1 -> Neg (gen_expr (depth - 1))
+    | 2 -> Add (gen_expr (depth - 1), gen_expr (depth - 1))
+    | 3 -> Many (List.init (Random.int 5) (fun _ -> gen_expr (depth - 1)))
+    | _ -> Lab (string_of_int (Random.int 1000), gen_expr (depth - 1))
+
+let tag_counter = ref 0
+
+let hc node =
+  incr tag_counter;
+  { node; tag = !tag_counter }
+
+let rec gen_tree depth =
+  if depth <= 0 then hc (Leaf (Random.int 1_000_000))
+  else
+    match Random.int 2 with
+    | 0 -> hc (Leaf (Random.int 1_000_000))
+    | _ -> hc (Branch (gen_tree (depth - 1), gen_tree (depth - 1)))
+
+let sample n f = Array.init n (fun _ -> f ())
+
+(* ---- Measurement ---- *)
+
+let measure name ~reps arr hash =
+  let n = Array.length arr in
+  (* warmup *)
+  let acc = ref 0 in
+  for i = 0 to n - 1 do
+    acc := !acc lxor hash (Array.unsafe_get arr i)
+  done;
+  Gc.full_major ();
+  let a0 = Gc.allocated_bytes () in
+  let t0 = Unix.gettimeofday () in
+  for _ = 1 to reps do
+    for i = 0 to n - 1 do
+      acc := !acc lxor hash (Array.unsafe_get arr i)
+    done
+  done;
+  let t1 = Unix.gettimeofday () in
+  let a1 = Gc.allocated_bytes () in
+  ignore (Sys.opaque_identity !acc);
+  let total = float_of_int (reps * n) in
+  Printf.printf "  %-24s %7.2f ns/op   %6.1f B/op\n%!" name
+    ((t1 -. t0) *. 1e9 /. total)
+    ((a1 -. a0) /. total)
+
+let group title arr ~reps derived =
+  Printf.printf "%s (n=%d)\n" title (Array.length arr);
+  measure "derived hash" ~reps arr derived;
+  measure "Stdlib.Hashtbl.hash" ~reps arr Hashtbl.hash;
+  print_newline ()
+
+let () =
+  group "expr (recursive, lists)"
+    (sample 100_000 (fun () -> gen_expr 6))
+    ~reps:50 hash_expr;
+  group "rgb (record)"
+    (sample 200_000 (fun () ->
+         { r = Random.int 256; g = Random.int 256; b = Random.int 256 }))
+    ~reps:200 hash_rgb;
+  group "pair (tuple)"
+    (sample 200_000 (fun () -> (Random.int 100000, Random.int 100000)))
+    ~reps:200 hash_pair;
+  group "flat (enum)"
+    (sample 200_000 (fun () ->
+         [| A; B; C; D; E |].(Random.int 5)))
+    ~reps:200 hash_flat;
+  group "ints (int list)"
+    (sample 100_000 (fun () -> List.init (Random.int 16) (fun _ -> Random.int 1000)))
+    ~reps:100 hash_ints;
+  group "matrix (int list list)"
+    (sample 50_000 (fun () ->
+         List.init (Random.int 8) (fun _ ->
+             List.init (Random.int 8) (fun _ -> Random.int 1000))))
+    ~reps:50 hash_matrix;
+  group "tree (recursive via alias)"
+    (sample 100_000 (fun () -> gen_tree 6))
+    ~reps:50 hash_tree

--- a/bench/dune
+++ b/bench/dune
@@ -1,0 +1,5 @@
+(executable
+ (name bench)
+ (libraries unix)
+ (preprocess
+  (pps ppx_deriving_hash)))

--- a/src/ppx_deriving_hash.ml
+++ b/src/ppx_deriving_hash.ml
@@ -21,10 +21,23 @@ let hash_reduce ~loc = function
 
 let hash_variant ~loc i = eint ~loc i
 
+(* Apply a hash function [f] to a value [x], flattening when [f] is itself an
+   application (e.g. [List.fold_left g 0] or [hash_t poly_a]) so the result is a
+   single saturated application. This avoids materializing the intermediate
+   partial-application closure, which would otherwise be allocated on every
+   call. *)
+let app ~loc f x =
+  match f.pexp_desc with
+  | Pexp_apply (g, args) -> pexp_apply ~loc g (args @ [ (Nolabel, x) ])
+  | _ -> pexp_apply ~loc f [ (Nolabel, x) ]
+
 let rec expr ~loc ~quoter ct =
   match Attribute.get attr_hash ct with
   | Some hash ->
-    Ppx_deriving.quote ~quoter hash
+    (* Inline the override directly. Hoisting it into a local binding (via the
+       quoter) would make any enclosing fold lambda capture that local,
+       forcing a per-call closure allocation. *)
+    hash
   | None ->
     let expr = expr ~quoter in
     match ct with
@@ -44,30 +57,38 @@ let rec expr ~loc ~quoter ct =
     | [%type: unit] ->
       [%expr fun () -> [%e hash_empty ~loc]]
     | [%type: [%t? a] ref] ->
-      [%expr fun x -> [%e expr ~loc a] !x]
+      [%expr fun x -> [%e app ~loc (expr ~loc a) [%expr !x]]]
     | [%type: [%t? a] option] ->
       [%expr function
         (* like variants *)
         | None -> [%e hash_variant ~loc 0]
-        | Some x -> [%e hash_reduce2 ~loc (hash_variant ~loc 1) [%expr [%e expr ~loc a] x]]
+        | Some x -> [%e hash_reduce2 ~loc (hash_variant ~loc 1) (app ~loc (expr ~loc a) [%expr x])]
       ]
     | [%type: [%t? a] list] ->
-      [%expr List.fold_left (fun a b -> [%e hash_reduce2 ~loc [%expr a] [%expr [%e expr ~loc a] b]]) [%e hash_empty ~loc]]
+      let elt = expr ~loc a in
+      (* The fold lambda references only [elt]; for a named/primitive element
+         hash it is therefore a closed term, allocated statically rather than
+         rebuilt per call. The element is applied via [app] so that nested
+         containers stay flat (saturated) applications. *)
+      [%expr Stdlib.List.fold_left
+          (fun acc__ x__ -> [%e hash_reduce2 ~loc [%expr acc__] (app ~loc elt [%expr x__])])
+          [%e hash_empty ~loc]]
     | [%type: [%t? a] array] ->
-      [%expr Array.fold_left (fun a b -> [%e hash_reduce2 ~loc [%expr a] [%expr [%e expr ~loc a] b]]) [%e hash_empty ~loc]]
+      let elt = expr ~loc a in
+      [%expr Stdlib.Array.fold_left
+          (fun acc__ x__ -> [%e hash_reduce2 ~loc [%expr acc__] (app ~loc elt [%expr x__])])
+          [%e hash_empty ~loc]]
     | [%type: [%t? a] lazy_t]
     | [%type: [%t? a] Lazy.t] ->
-      [%expr fun (lazy x) -> [%e expr ~loc a] x]
+      [%expr fun (lazy x) -> [%e app ~loc (expr ~loc a) [%expr x]]]
     | {ptyp_desc = Ptyp_constr ({txt = lid; loc}, args); _} ->
       let ident = pexp_ident ~loc {loc; txt = Ppx_deriving.mangle_lid mangle_affix lid} in
-      let ident = Ppx_deriving.quote ~quoter ident in
-      let apply_args =
-        args
-        |> List.map (fun ct ->
-            (Nolabel, expr ~loc ct)
-          )
-      in
-      pexp_apply ~loc ident apply_args
+      (* Reference the hash function directly (no quoter alias): keeps enclosing
+         fold lambdas closed, hence allocation-free. The (possibly partial)
+         application is saturated at the use site by [app]. *)
+      (match args with
+       | [] -> ident
+       | _ -> pexp_apply ~loc ident (List.map (fun ct -> (Nolabel, expr ~loc ct)) args))
     | {ptyp_desc = Ptyp_tuple comps; _} ->
       expr_tuple ~loc ~quoter comps
     | {ptyp_desc = Ptyp_variant (rows, Closed, None); _} ->
@@ -93,7 +114,7 @@ and expr_poly_variant ~loc ~quoter rows =
         let label_fun = expr ~loc ~quoter ct in
         case ~lhs:(ppat_variant ~loc label (Some [%pat? x]))
           ~guard:None
-          ~rhs:(hash_reduce2 ~loc variant_const [%expr [%e label_fun] x])
+          ~rhs:(hash_reduce2 ~loc variant_const (app ~loc label_fun [%expr x]))
       | _ ->
         Location.raise_errorf ~loc "other variant"
     )
@@ -119,7 +140,7 @@ and expr_variant ~loc ~quoter constrs =
               (i, expr ~loc ~quoter comp_type)
             )
           |> List.map (fun (i, label_fun) ->
-              [%expr [%e label_fun] [%e label_field ~loc "x" i]]
+              app ~loc label_fun (label_field ~loc "x" i)
             )
           |> hash_fold ~loc variant_const
         in
@@ -145,7 +166,7 @@ and expr_variant ~loc ~quoter constrs =
               (label, expr ~loc ~quoter pld_type)
             )
           |> List.map (fun (label, label_fun) ->
-              [%expr [%e label_fun] [%e label_field ~loc x_expr label]]
+              app ~loc label_fun (label_field ~loc x_expr label)
             )
           |> hash_fold ~loc variant_const
         in
@@ -168,7 +189,7 @@ and expr_record ~loc ~quoter lds =
         (label, expr ~loc ~quoter pld_type)
       )
     |> List.map (fun (label, label_fun) ->
-        [%expr [%e label_fun] [%e label_field ~loc x_expr label]]
+        app ~loc label_fun (label_field ~loc x_expr label)
       )
     |> hash_reduce ~loc
   in
@@ -185,7 +206,7 @@ and expr_tuple ~loc ~quoter comps =
         (i, expr ~loc ~quoter comp_type)
       )
     |> List.map (fun (i, label_fun) ->
-        [%expr [%e label_fun] [%e label_field ~loc "x" i]]
+        app ~loc label_fun (label_field ~loc "x" i)
       )
     |> hash_reduce ~loc
   in
@@ -201,7 +222,11 @@ and expr_tuple ~loc ~quoter comps =
 
 let expr_declaration ~loc ~quoter td = match td with
   | {ptype_kind = Ptype_abstract; ptype_manifest = Some ct; _} ->
-    expr ~loc ~quoter ct
+    let e = expr ~loc ~quoter ct in
+    (* Eta-expand to obtain a valid function literal. *)
+    (match e.pexp_desc with
+     | Pexp_apply _ -> [%expr fun x__ -> [%e app ~loc e [%expr x__]]]
+     | _ -> e)
   | {ptype_kind = Ptype_abstract; _} ->
     Location.raise_errorf ~loc "Cannot derive accessors for abstract types"
   | {ptype_kind = Ptype_variant constrs; _} ->
@@ -218,18 +243,27 @@ let typ ~loc td =
     td
     [%type: [%t ct] -> int]
 
+(* Fixpoint of coalesce_arity *)
+let rec coalesce_arity_full e =
+  let e' = coalesce_arity e in
+  if e' == e then e else coalesce_arity_full e'
+
 let generate_impl ~ctxt (_rec_flag, type_declarations) =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   type_declarations
   |> List.map (fun td ->
       let quoter = Ppx_deriving.create_quoter () in
       let expr = expr_declaration ~loc ~quoter td in
-      let expr = Ppx_deriving.sanitize ~quoter expr in
       let expr = Ppx_deriving.poly_fun_of_type_decl td expr in
+      (* Merge the [poly_*] parameters and the matched value into a single
+         function of the full arity (avoids allocation). *)
+      let expr = coalesce_arity_full expr in
+      (* Deliberately no wrapped in [Ppx_deriving.sanitize] as it breaks arity merging.
+         The generated code only uses plain Stdlib. *)
       let ct = typ ~loc td in
       let pat = ppat_var ~loc {loc; txt = Ppx_deriving.mangle_type_decl mangle_affix td} in
       let pat = ppat_constraint ~loc pat ct in
-      Ast_helper.Vb.mk ~loc ~attrs:[Ppx_deriving.attr_warning [%expr "-39"]] pat expr
+      Ast_helper.Vb.mk ~loc ~attrs:[Ppx_deriving.attr_warning [%expr "-a"]] pat expr
     )
   |> Ast_helper.Str.value ~loc Recursive
   |> fun v -> [v]

--- a/src/ppx_deriving_hash.ml
+++ b/src/ppx_deriving_hash.ml
@@ -21,16 +21,6 @@ let hash_reduce ~loc = function
 
 let hash_variant ~loc i = eint ~loc i
 
-(* Apply a hash function [f] to a value [x], flattening when [f] is itself an
-   application (e.g. [List.fold_left g 0] or [hash_t poly_a]) so the result is a
-   single saturated application. This avoids materializing the intermediate
-   partial-application closure, which would otherwise be allocated on every
-   call. *)
-let app ~loc f x =
-  match f.pexp_desc with
-  | Pexp_apply (g, args) -> pexp_apply ~loc g (args @ [ (Nolabel, x) ])
-  | _ -> pexp_apply ~loc f [ (Nolabel, x) ]
-
 let rec expr ~loc ~quoter ct =
   match Attribute.get attr_hash ct with
   | Some hash ->
@@ -57,38 +47,37 @@ let rec expr ~loc ~quoter ct =
     | [%type: unit] ->
       [%expr fun () -> [%e hash_empty ~loc]]
     | [%type: [%t? a] ref] ->
-      [%expr fun x -> [%e app ~loc (expr ~loc a) [%expr !x]]]
+      [%expr fun x -> [%e expr ~loc a] !x]
     | [%type: [%t? a] option] ->
       [%expr function
         (* like variants *)
         | None -> [%e hash_variant ~loc 0]
-        | Some x -> [%e hash_reduce2 ~loc (hash_variant ~loc 1) (app ~loc (expr ~loc a) [%expr x])]
+        | Some x -> [%e hash_reduce2 ~loc (hash_variant ~loc 1) [%expr [%e expr ~loc a] x]]
       ]
     | [%type: [%t? a] list] ->
       let elt = expr ~loc a in
       (* The fold lambda references only [elt]; for a named/primitive element
-         hash it is therefore a closed term, allocated statically rather than
-         rebuilt per call. The element is applied via [app] so that nested
-         containers stay flat (saturated) applications. *)
+         hash (no quoter alias) it is therefore a closed term, allocated
+         statically rather than rebuilt per call. Fresh [acc__]/[x__] names
+         avoid capturing any binding that an inline [@hash] element override
+         might mention. *)
       [%expr Stdlib.List.fold_left
-          (fun acc__ x__ -> [%e hash_reduce2 ~loc [%expr acc__] (app ~loc elt [%expr x__])])
+          (fun acc__ x__ -> [%e hash_reduce2 ~loc [%expr acc__] [%expr [%e elt] x__]])
           [%e hash_empty ~loc]]
     | [%type: [%t? a] array] ->
       let elt = expr ~loc a in
       [%expr Stdlib.Array.fold_left
-          (fun acc__ x__ -> [%e hash_reduce2 ~loc [%expr acc__] (app ~loc elt [%expr x__])])
+          (fun acc__ x__ -> [%e hash_reduce2 ~loc [%expr acc__] [%expr [%e elt] x__]])
           [%e hash_empty ~loc]]
     | [%type: [%t? a] lazy_t]
     | [%type: [%t? a] Lazy.t] ->
-      [%expr fun (lazy x) -> [%e app ~loc (expr ~loc a) [%expr x]]]
+      [%expr fun (lazy x) -> [%e expr ~loc a] x]
     | {ptyp_desc = Ptyp_constr ({txt = lid; loc}, args); _} ->
       let ident = pexp_ident ~loc {loc; txt = Ppx_deriving.mangle_lid mangle_affix lid} in
       (* Reference the hash function directly (no quoter alias): keeps enclosing
-         fold lambdas closed, hence allocation-free. The (possibly partial)
-         application is saturated at the use site by [app]. *)
-      (match args with
-       | [] -> ident
-       | _ -> pexp_apply ~loc ident (List.map (fun ct -> (Nolabel, expr ~loc ct)) args))
+         fold lambdas closed, hence allocation-free. [pexp_apply] returns
+         [ident] unchanged when there are no type arguments. *)
+      pexp_apply ~loc ident (List.map (fun ct -> (Nolabel, expr ~loc ct)) args)
     | {ptyp_desc = Ptyp_tuple comps; _} ->
       expr_tuple ~loc ~quoter comps
     | {ptyp_desc = Ptyp_variant (rows, Closed, None); _} ->
@@ -114,7 +103,7 @@ and expr_poly_variant ~loc ~quoter rows =
         let label_fun = expr ~loc ~quoter ct in
         case ~lhs:(ppat_variant ~loc label (Some [%pat? x]))
           ~guard:None
-          ~rhs:(hash_reduce2 ~loc variant_const (app ~loc label_fun [%expr x]))
+          ~rhs:(hash_reduce2 ~loc variant_const [%expr [%e label_fun] x])
       | _ ->
         Location.raise_errorf ~loc "other variant"
     )
@@ -140,7 +129,7 @@ and expr_variant ~loc ~quoter constrs =
               (i, expr ~loc ~quoter comp_type)
             )
           |> List.map (fun (i, label_fun) ->
-              app ~loc label_fun (label_field ~loc "x" i)
+              [%expr [%e label_fun] [%e label_field ~loc "x" i]]
             )
           |> hash_fold ~loc variant_const
         in
@@ -166,7 +155,7 @@ and expr_variant ~loc ~quoter constrs =
               (label, expr ~loc ~quoter pld_type)
             )
           |> List.map (fun (label, label_fun) ->
-              app ~loc label_fun (label_field ~loc x_expr label)
+              [%expr [%e label_fun] [%e label_field ~loc x_expr label]]
             )
           |> hash_fold ~loc variant_const
         in
@@ -189,7 +178,7 @@ and expr_record ~loc ~quoter lds =
         (label, expr ~loc ~quoter pld_type)
       )
     |> List.map (fun (label, label_fun) ->
-        app ~loc label_fun (label_field ~loc x_expr label)
+        [%expr [%e label_fun] [%e label_field ~loc x_expr label]]
       )
     |> hash_reduce ~loc
   in
@@ -206,7 +195,7 @@ and expr_tuple ~loc ~quoter comps =
         (i, expr ~loc ~quoter comp_type)
       )
     |> List.map (fun (i, label_fun) ->
-        app ~loc label_fun (label_field ~loc "x" i)
+        [%expr [%e label_fun] [%e label_field ~loc "x" i]]
       )
     |> hash_reduce ~loc
   in
@@ -223,9 +212,13 @@ and expr_tuple ~loc ~quoter comps =
 let expr_declaration ~loc ~quoter td = match td with
   | {ptype_kind = Ptype_abstract; ptype_manifest = Some ct; _} ->
     let e = expr ~loc ~quoter ct in
-    (* Eta-expand to obtain a valid function literal. *)
+    (* When the alias expands to an application (e.g. a parametrized alias such
+       as [type t = u hash_consed], or an alias to a container), eta-expand it
+       into a function literal. A bare application is not a legal right-hand
+       side of the [let rec] this deriver emits; the [fun x__ -> _ x__] wrapper
+       is. *)
     (match e.pexp_desc with
-     | Pexp_apply _ -> [%expr fun x__ -> [%e app ~loc e [%expr x__]]]
+     | Pexp_apply _ -> [%expr fun x__ -> [%e e] x__]
      | _ -> e)
   | {ptype_kind = Ptype_abstract; _} ->
     Location.raise_errorf ~loc "Cannot derive accessors for abstract types"

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,4 @@
+(test
+ (name test)
+ (preprocess
+  (pps ppx_deriving_hash)))

--- a/test/test.ml
+++ b/test/test.ml
@@ -23,7 +23,6 @@ type refd = int ref [@@deriving hash]
 type lazyd = int lazy_t [@@deriving hash]
 type 'a poly = Nil | Cons of 'a * 'a poly [@@deriving hash]
 
-(* Recursive type via a parametrized alias (the hash-consing shape). *)
 type 'a hash_consed = { node : 'a; tag : int }
 
 let hash_hash_consed _ x = x.tag
@@ -31,8 +30,24 @@ let hash_hash_consed _ x = x.tag
 type tree_kind = TLeaf of int | TBranch of tree * tree
 and tree = tree_kind hash_consed [@@deriving hash]
 
-(* Override via [@hash]. *)
+
 type wrapped = { raw : (int[@hash fun x -> x + 1]) } [@@deriving hash]
+type pvar = [ `A | `B of int | `C of string ] [@@deriving hash]
+type inline = Inl of { x : int; y : string } | Plain [@@deriving hash]
+
+type units = unit [@@deriving hash]
+type i32 = int32 [@@deriving hash]
+type i64 = int64 [@@deriving hash]
+
+type ('a, 'b) two = Two of 'a * 'b [@@deriving hash]
+
+type pairs = (int * int) list [@@deriving hash]
+type rgb_arr = rgb array [@@deriving hash]
+
+type ints = int list [@@deriving hash]
+type 'a opt_alias = 'a option [@@deriving hash]
+
+type wrapped_list = (int[@hash fun x -> x + 1]) list [@@deriving hash]
 
 let failures = ref 0
 
@@ -84,6 +99,43 @@ let () =
   check "tree via alias" (hash_tree t = t.tag);
   check "hash override applied" (hash_wrapped { raw = 10 } <> hash_wrapped { raw = 11 });
 
+  (* Polymorphic variants *)
+  check "poly variant equal" (hash_pvar (`B 1) = hash_pvar (`B 1));
+  check "poly variant differ" (hash_pvar (`B 1) <> hash_pvar (`C "x"));
+  check "poly variant const differ" (hash_pvar `A <> hash_pvar (`B 1));
+
+  (* Inline record in a constructor *)
+  check "inline record equal"
+    (hash_inline (Inl { x = 1; y = "a" }) = hash_inline (Inl { x = 1; y = "a" }));
+  check "inline record differ" (hash_inline (Inl { x = 1; y = "a" }) <> hash_inline Plain);
+
+  (* Extra primitive leaves *)
+  check "unit" (hash_units () = hash_units ());
+  check "int32" (hash_i32 7l = hash_i32 7l && hash_i32 7l <> hash_i32 8l);
+  check "int64" (hash_i64 7L = hash_i64 7L && hash_i64 7L <> hash_i64 8L);
+
+  (* Two type parameters *)
+  check "two params equal"
+    (hash_two (fun x -> x) Char.code (Two (1, 'a'))
+     = hash_two (fun x -> x) Char.code (Two (1, 'a')));
+  check "two params differ"
+    (hash_two (fun x -> x) Char.code (Two (1, 'a'))
+     <> hash_two (fun x -> x) Char.code (Two (1, 'b')));
+
+  (* Structured elements inside containers *)
+  check "pairs equal" (hash_pairs [ (1, 2); (3, 4) ] = hash_pairs [ (1, 2); (3, 4) ]);
+  check "pairs differ" (hash_pairs [ (1, 2) ] <> hash_pairs [ (2, 1) ]);
+  check "rgb array equal"
+    (hash_rgb_arr [| { r = 1; g = 2; b = 3 } |] = hash_rgb_arr [| { r = 1; g = 2; b = 3 } |]);
+
+  (* Alias expanding to a bare application *)
+  check "int list alias" (hash_ints [ 1; 2; 3 ] = hash_ints [ 1; 2; 3 ]);
+  check "option alias"
+    (hash_opt_alias (fun x -> x) (Some 1) <> hash_opt_alias (fun x -> x) None);
+
+  (* [@hash] override on a container element *)
+  check "override in list applied" (hash_wrapped_list [ 10 ] <> hash_wrapped_list [ 11 ]);
+
   (* Allocation-freedom *)
   check_no_alloc "expr" hash_expr e;
   check_no_alloc "nested" hash_nested [| [ [ 1; 2; 3 ]; [ 4; 5 ] ]; [ [ 6 ] ] |];
@@ -91,6 +143,17 @@ let () =
   check_no_alloc "pair" hash_pair (4, 5);
   check_no_alloc "tree" hash_tree t;
   check_no_alloc "list" (hash_poly (fun x -> x)) (Cons (1, Cons (2, Cons (3, Nil))));
+  (* primitives mixed (incl. a float field, which must not re-box on read) *)
+  check_no_alloc "prim" hash_prim { i = 1; b = true; c = 'a'; s = "x"; f = 3.5 };
+  check_no_alloc "option" hash_opt (Some 5);
+  check_no_alloc "ref" hash_refd (ref 7);
+  check_no_alloc "lazy" hash_lazyd (lazy 9);
+  check_no_alloc "poly variant" hash_pvar (`B 1);
+  check_no_alloc "inline record" hash_inline (Inl { x = 1; y = "a" });
+  check_no_alloc "two params" (hash_two (fun x -> x) Char.code) (Two (1, 'a'));
+  check_no_alloc "pairs" hash_pairs [ (1, 2); (3, 4); (5, 6) ];
+  check_no_alloc "rgb array" hash_rgb_arr [| { r = 1; g = 2; b = 3 } |];
+  check_no_alloc "override in list" hash_wrapped_list [ 10; 20; 30 ];
 
   if !failures = 0 then print_endline "All tests passed."
   else (

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,0 +1,98 @@
+(* Tests for [@@deriving hash]:
+   - the various type shapes compile (notably a recursive type reached through a
+     parametrized alias, which must be a valid [let rec] right-hand side);
+   - [hash] is consistent with structural equality;
+   - [hash] never allocates. *)
+
+type flat = A | B | C [@@deriving hash]
+type rgb = { r : int; g : int; b : int } [@@deriving hash]
+type pair = int * int [@@deriving hash]
+type prim = { i : int; b : bool; c : char; s : string; f : float } [@@deriving hash]
+
+type expr =
+  | Lit of int
+  | Neg of expr
+  | Add of expr * expr
+  | Many of expr list
+  | Lab of string * expr
+[@@deriving hash]
+
+type nested = int list list array [@@deriving hash]
+type opt = int option [@@deriving hash]
+type refd = int ref [@@deriving hash]
+type lazyd = int lazy_t [@@deriving hash]
+type 'a poly = Nil | Cons of 'a * 'a poly [@@deriving hash]
+
+(* Recursive type via a parametrized alias (the hash-consing shape). *)
+type 'a hash_consed = { node : 'a; tag : int }
+
+let hash_hash_consed _ x = x.tag
+
+type tree_kind = TLeaf of int | TBranch of tree * tree
+and tree = tree_kind hash_consed [@@deriving hash]
+
+(* Override via [@hash]. *)
+type wrapped = { raw : (int[@hash fun x -> x + 1]) } [@@deriving hash]
+
+let failures = ref 0
+
+let check name cond =
+  if cond then Printf.printf "  ok   %s\n" name
+  else (
+    incr failures;
+    Printf.printf "  FAIL %s\n" name)
+
+(* Assert a hash function does not allocate, by hashing one value in a tight
+   loop and checking the per-call allocation rounds to zero. *)
+let check_no_alloc name hash v =
+  let n = 1_000_000 in
+  let acc = ref 0 in
+  acc := !acc lxor hash v;
+  (* warm up / no-op to stabilize *)
+  let a0 = Gc.allocated_bytes () in
+  for _ = 1 to n do
+    acc := !acc lxor hash v
+  done;
+  let a1 = Gc.allocated_bytes () in
+  ignore (Sys.opaque_identity !acc);
+  let per_op = (a1 -. a0) /. float_of_int n in
+  check (Printf.sprintf "%s allocates %.3f B/op (expected ~0)" name per_op)
+    (per_op < 1.0)
+
+let () =
+  (* Determinism *)
+  let e = Add (Lit 1, Many [ Neg (Lit 2); Lab ("x", Lit 3) ]) in
+  check "deterministic" (hash_expr e = hash_expr e);
+
+  (* Consistency with structural equality *)
+  let e2 = Add (Lit 1, Many [ Neg (Lit 2); Lab ("x", Lit 3) ]) in
+  check "equal values -> equal hash" (hash_expr e = hash_expr e2);
+  check "rgb equal" (hash_rgb { r = 1; g = 2; b = 3 } = hash_rgb { r = 1; g = 2; b = 3 });
+  check "pair equal" (hash_pair (4, 5) = hash_pair (4, 5));
+  check "list equal" (hash_expr (Many [ Lit 1; Lit 2 ]) = hash_expr (Many [ Lit 1; Lit 2 ]));
+
+  (* Distinct values usually hash differently (sanity, not guaranteed) *)
+  check "distinct differ" (hash_expr (Lit 1) <> hash_expr (Lit 2));
+
+  (* Compile/usage smoke for the trickier shapes *)
+  check "nested compiles" (hash_nested [| [ [ 1; 2 ]; [ 3 ] ] |] = hash_nested [| [ [ 1; 2 ]; [ 3 ] ] |]);
+  check "option" (hash_opt (Some 1) <> hash_opt None);
+  check "ref" (hash_refd (ref 7) = hash_refd (ref 7));
+  check "lazy" (hash_lazyd (lazy 9) = hash_lazyd (lazy 9));
+  check "poly" (hash_poly (fun x -> x) (Cons (1, Nil)) = hash_poly (fun x -> x) (Cons (1, Nil)));
+  let t = { node = TBranch ({ node = TLeaf 1; tag = 1 }, { node = TLeaf 2; tag = 2 }); tag = 3 } in
+  check "tree via alias" (hash_tree t = t.tag);
+  check "hash override applied" (hash_wrapped { raw = 10 } <> hash_wrapped { raw = 11 });
+
+  (* Allocation-freedom *)
+  check_no_alloc "expr" hash_expr e;
+  check_no_alloc "nested" hash_nested [| [ [ 1; 2; 3 ]; [ 4; 5 ] ]; [ [ 6 ] ] |];
+  check_no_alloc "rgb" hash_rgb { r = 1; g = 2; b = 3 };
+  check_no_alloc "pair" hash_pair (4, 5);
+  check_no_alloc "tree" hash_tree t;
+  check_no_alloc "list" (hash_poly (fun x -> x)) (Cons (1, Cons (2, Cons (3, Nil))));
+
+  if !failures = 0 then print_endline "All tests passed."
+  else (
+    Printf.printf "%d failure(s).\n" !failures;
+    exit 1)


### PR DESCRIPTION
Hello! we'd like to use `ppx_deriving_hash` for [Soteria](https://github.com/soteria-tools/soteria/pull/416) but, currently, hand-written hashing functions perform better for recursive types, and the pattern we need fails to compile.

### AI Disclaimer

I've used AI to generate the code, tests and benchmarks, and to explore why allocation was happening and why the pattern of hashconsing was broken. I've also used help to write the PR description below.
I did, however read the entirety of the code, rewrote anything I didn't like, etc. If anything I have followed Soteria's own [AI policy](https://github.com/soteria-tools/soteria/blob/main/AI_POLICY.md).

### No Allocation

Before this PR, `[@@deriving hash]` would allocate on every call for recursive/polymorphic/container types.
Allocation is expensive, and we should remove as much as possible.

Three causes, each fixed:

**1. Captured closures in folds.** The element hash was hoisted into a local and captured
by the fold lambda, allocating a fresh closure per call:
```ocaml
type expr = Lit of int | Many of expr list [@@deriving hash]
(* This would generate something of the form *)

let rec hash_expr e =
   let __0 = hash_expr in
   match e with
   | Many x -> (* ... *) List.fold-left (fun a b -> 31*a + __0 b) 0 x
   | ...

```
Because `hash_expr` is captured by the closure, the compiler cannot inline it nicely and it is allocated on every call.
The generated code now references `hash_expr` directly, we obtain a closed statically-allocated lambda.

~~**2. Partial applications in element position.** `(List.fold_left f 0) x` and `hash_t
poly_a x` built an intermediate closure. Now applied as flat applications.~~

**3. Hidden arity on polymorphic types.** `fun poly_a -> function …` compiles to
arity-1-returning-arity-1, so the recursive call `hash_t poly_a x` allocated a closure
each time. Parameters are now coalesced to full arity → direct call.

### Mutually recursive types with aliasing

A recursive type through a parametrized alias didn't compile before. Take the example of hashconsing a simple AST.
```ocaml
(* a generic hash-consed wrapper: a value + its unique tag *)
type 'a hash_consed = { node : 'a; tag : int }
let hash_hash_consed _ h = h.tag   (* hash by tag — children are already interned *)

(* an expression language where every subterm is hash-consed *)
type expr_node =
  | Int of int
  | Add of expr * expr
and expr = expr_node hash_consed
[@@deriving hash]
  
(* generates code that didn't compile *)
let rec hash_expr_node = function
  | Int x -> ...
  | Add (l, r) -> ... hash_expr l ... hash_expr r ...
and hash_expr = hash_hash_consed hash_expr_node (* <- error *)
```

The alias hash is now eta-expanded into a function literal.

### Tests and Benchmarks

Hash values are unchanged. Added `bench/` (vs `Stdlib.Hashtbl.hash`) and `test/`
(correctness + allocation assertions); the repo previously had no tests.

***Results (derived vs `Stdlib.Hashtbl.hash`, all 0 B/op)***
| type | before | after |
|---|---|---|
| recursive + lists | 79.7 B/op | 0 B/op |
| record / tuple / enum | 0 B/op, ~1 ns (3–6× faster than Hashtbl.hash) | unchanged |
| recursive poly type | allocated per node | 0 B/op |


***Note***: On very big values (e.g. a list of size 10000), Hashtbl.hash is faster than the derived hash because Hashtbl.hash uses fuel to stop after something like 10 elements I think.