### PR TITLE
Use `Ppxlib.really_recursive` for implementation

### DIFF
--- a/src/ppx_deriving_hash.ml
+++ b/src/ppx_deriving_hash.ml
@@ -218,7 +218,7 @@ let typ ~loc td =
     td
     [%type: [%t ct] -> int]
 
-let generate_impl ~ctxt (_rec_flag, type_declarations) =
+let generate_impl ~ctxt (rec_flag, type_declarations) =
   let loc = Expansion_context.Deriver.derived_item_loc ctxt in
   Ast_helper.with_default_loc loc @@ fun () -> (* ppx_deriving_hash shouldn't be using default_loc, but some of the Ppx_deriving API calls might *)
   type_declarations
@@ -239,7 +239,7 @@ let generate_impl ~ctxt (_rec_flag, type_declarations) =
       let pat = ppat_constraint ~loc pat ct in
       Ast_helper.Vb.mk ~loc ~attrs:[Ppx_deriving.attr_warning [%expr "-39"]] pat expr
     )
-  |> Ast_helper.Str.value ~loc Recursive
+  |> Ast_helper.Str.value ~loc (really_recursive rec_flag type_declarations)
   |> fun v -> [v]
 
 let impl_generator = Deriving.Generator.V2.make_noarg generate_impl

--- a/test/giltho/alloc.ml
+++ b/test/giltho/alloc.ml
@@ -29,9 +29,7 @@ let tests =
       "inline record" >:: test_no_alloc hash_inline (Inl { x = 1; y = "a" });
       "two params" >:: test_no_alloc (hash_two (fun x -> x) Char.code) (Two (1, 'a'));
       "pairs" >:: test_no_alloc hash_pairs [ (1, 2); (3, 4); (5, 6) ];
-#if OCAML_VERSION < (5, 2, 0)
       "rgb array" >:: test_no_alloc hash_rgb_arr [| { r = 1; g = 2; b = 3 } |];
       "override in list" >:: test_no_alloc hash_wrapped_list [ 10; 20; 30 ];
-#endif
     ];
   ]


### PR DESCRIPTION
Currently the implementation is always recursive.
This can be inefficient because recursive functions are compiled differently: https://github.com/ocaml/ocaml/issues/14876#issuecomment-4825973808. This makes all tests pass even on OCaml 5.5 because the failing ones are non-recursive.

### TODO
- [x] Benchmark with Goblint (together with https://github.com/ocaml-ppx/ppx_deriving/pull/307): No difference on OCaml 4.14, maybe 1% CPU time improvement on OCaml 5.6.0+trunk.